### PR TITLE
allow Annotation contains `"`

### DIFF
--- a/plans/plans.go
+++ b/plans/plans.go
@@ -135,7 +135,8 @@ func (ans Annotations) marshal() []Annotation {
 }
 
 func (ans Annotations) MarshalJSON() ([]byte, error) {
-	return json.Marshal(ans.marshal())
+	s := ans.marshal()
+	return json.Marshal(s)
 }
 
 type Annotation struct {
@@ -152,7 +153,8 @@ func (an Annotation) Equal(o Annotation) bool {
 }
 
 func (an Annotation) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf(`"%s=%s"`, an.Key, an.Value)), nil
+	s := an.String()
+	return json.Marshal(s)
 }
 
 func (an Annotation) MarshalYAML() (interface{}, error) {

--- a/plans/plans_test.go
+++ b/plans/plans_test.go
@@ -208,6 +208,17 @@ func TestAnnotations_marshalling(t *testing.T) {
 		},
 	))
 
+	t.Run("contains quote", theory(
+		When{
+			Annotations: plans.Annotations{
+				{Key: `"key"`, Value: `"value"`},
+			},
+		},
+		Then{
+			StringExpression: `["\"key\"=\"value\""]`,
+		},
+	))
+
 	t.Run("multiple", theory(
 		When{
 			Annotations: plans.Annotations{


### PR DESCRIPTION
## About This PR

Allow `"` in Annotations.

Before this change, Annotations containing `"` cannot be marshaled to JSON. This PR fixes that.

## Related Issues

closes #10 .