### PR TITLE
`data.Detail`: make Log Upstream different from Output Upstream

### DIFF
--- a/data/data.go
+++ b/data/data.go
@@ -53,10 +53,26 @@ func (d Detail) Equal(o Detail) bool {
 		cmp.SliceEqualUnordered(d.Nomination, o.Nomination)
 }
 
+// CreatedFrom represents the source of the data
+type CreatedFrom struct {
+	// Mountpoint is the mountpoint which created this Data.
+	//
+	// This and Log are mutually exclusive.
+	Mountpoint *plans.Mountpoint `json:"mountpoint,omitempty"`
+
+	// Log is the log point which created this Data.
+	//
+	// This and Mountpoint are mutually exclusive.
+	Log *plans.LogPoint `json:"log,omitempty"`
+
+	// Run is the Run which created this Data.
+	Run runs.Summary `json:"run"`
+}
+
 // assigment representation, looking from data
 type AssignedTo struct {
-	plans.Mountpoint
-	Run runs.Summary `json:"run"`
+	Mountpoint plans.Mountpoint `json:"mountpoint"`
+	Run        runs.Summary     `json:"run"`
 }
 
 func (a AssignedTo) Equal(o AssignedTo) bool {

--- a/plans/plans.go
+++ b/plans/plans.go
@@ -284,16 +284,17 @@ func (m Mountpoint) Equal(o Mountpoint) bool {
 
 // Upstream is the format for input dependencies of a Plan.
 type Upstream struct {
-	Summary
+	// Plan is the upstream Plan.
+	Plan Summary `json:"plan"`
 
 	// Mountpoint represents the Output which is directt upstream.
 	//
-	// Log and Mountpoint are exclusive.
+	// Log and Mountpoint are mutually exclusive.
 	Mountpoint *Mountpoint `json:"mountpoint,omitempty"`
 
 	// Log represents the Log which is direct upstream.
 	//
-	// Log and Mountpoint are exclusive.
+	// Log and Mountpoint are mutually exclusive.
 	Log *LogPoint `json:"log,omitempty"`
 }
 
@@ -312,7 +313,7 @@ func (d Upstream) Equal(o Upstream) bool {
 	logMatch := (d.Log == nil && o.Log == nil) ||
 		d.Log.Equal(*o.Log)
 
-	return d.PlanId == o.PlanId && mountpointMatch && logMatch
+	return d.Plan.Equal(o.Plan) && mountpointMatch && logMatch
 }
 
 // Input is the format for input mountpoints of a Plan.
@@ -331,14 +332,15 @@ func (i Input) Equal(o Input) bool {
 
 // Downstream is the format for output dependencies of a Plan.
 type Downstream struct {
-	Summary
+	// Plan is the downstream Plan.
+	Plan Summary `json:"plan"`
 
 	// Mountpoint represents the Input which is direct downstream.
 	Mountpoint Mountpoint `json:"mountpoint"`
 }
 
 func (d Downstream) Equal(o Downstream) bool {
-	return d.PlanId == o.PlanId && d.Mountpoint.Equal(o.Mountpoint)
+	return d.Plan.Equal(o.Plan) && d.Mountpoint.Equal(o.Mountpoint)
 }
 
 // Output is the format for output mountpoints of a Plan.


### PR DESCRIPTION
This is BREAKING CHANGE in json format.

## Related Issues

- closes #29 
- opst/knitfab#214