### PR TITLE
fix JSON: `log.Tags` -> `log.tags`

### DIFF
--- a/plans/plans.go
+++ b/plans/plans.go
@@ -375,7 +375,7 @@ func (l Log) String() string {
 }
 
 type LogPoint struct {
-	Tags []tags.Tag
+	Tags []tags.Tag `json:"tags"`
 }
 
 func (lp LogPoint) Equal(o LogPoint) bool {


### PR DESCRIPTION
## About This PR

JSON key is CamelCased unintentionally.
Fix it to snasilCase.

Effected:

- Data Detail (`upstream.log.tags`)
- Run Detail (`log`)
- Plan Detail (`log`, `inputs[*].upstreams[*].log`)